### PR TITLE
Python 3.7/3.8 compatibility fixes

### DIFF
--- a/tigershark/X12/parse.py
+++ b/tigershark/X12/parse.py
@@ -677,7 +677,7 @@ class Segment( Parser ):
         """If this segment matches the next segment token in the input,
         create the X12Segment object.
         :param segments: list of SegmentTokens for the current message.
-        :returns: yields a single parsed Segment or raises StopIteration
+        :returns: yields a single parsed Segment or ends iteration (Yields)
         """
         if isinstance(self.repeat, int):
             length_loop = range(self.repeat)
@@ -694,7 +694,7 @@ class Segment( Parser ):
                 theSegment= self.theFactory.makeSegment( segments.pop(0), compPunct, self )
                 yield theSegment
             elif not required:
-                raise StopIteration
+                return
             else:
                 error= ParseError(
                     "Could not unmarshall {seg_name} Segment, "\
@@ -741,7 +741,7 @@ class Loop( Parser ):
         loops until a segment no longer matches.
 
         :param segments: list of SegmentToken instances
-        :returns: Yields the next X12.message.X12Loop structure or raises StopIteration
+        :returns: Yields the next X12.message.X12Loop structure or ends interation (returns)
         """
         # Confirm match between this loop and a segment of the structure
         i = 0
@@ -765,7 +765,7 @@ class Loop( Parser ):
                 i += 1
             else:
                 # Nothing left to check, so stop the iteration
-                raise StopIteration
+                return
 
     def match( self, candidate ):
         return self.structure[0].match( candidate )

--- a/tigershark/facade/__init__.py
+++ b/tigershark/facade/__init__.py
@@ -469,7 +469,7 @@ class X12SegmentBridge(object):
         sep = self.segment.message.getCompositeSeparator()
         result = []
         pos = 1
-        while self.segment.getByPos(pos) is not "":
+        while self.segment.getByPos(pos) != "":
             composite = self.segment.getByPos(pos)
             subElts = composite.split(sep)
             if subElts[0] in names:


### PR DESCRIPTION
This fixes two issues preventing this library from running on Python 3.7+:

1. Python 3.7 changed the behavior of yields. Raising `StopIteration` to end a yield loop doesn't work anymore and now terminates the program. You need to just `return` instead to end iteration. See https://www.python.org/dev/peps/pep-0479/ and https://stackoverflow.com/questions/6395063/yield-break-in-python.
2. You can't use `value is not ""` with a literal value anymore, only with objects. So `is not` needs to be changed to `!=`.

With this change, tests now pass on Python 3.6, 3.7 and. 3.8.