### PR TITLE
hcpcs_code_modifier extract has been added

### DIFF
--- a/tigershark/facade/f835.py
+++ b/tigershark/facade/f835.py
@@ -229,6 +229,7 @@ class Claim(Facade, X12LoopBridge):
         Rest assured I did not come to this decision lightly."""
         loopName = "2110"
         hcpcs_code = CompositeAccess("SVC", "HC", 1)
+        hcpcs_code_modifier = CompositeAccess("SVC", "HC", 2)
         charge = ElementAccess("SVC", 2, x12type=Money)
         payment = ElementAccess("SVC", 3, x12type=Money)
         quantity = ElementAccess("SVC", 5)


### PR DESCRIPTION
While processing a large batch of documents, I found that the Hcpcs code modifier was not being used. This modifier specifies which Hcpcs code is used. This is important for further analysis. Please accept this request.